### PR TITLE
Fix crates.io link under specifying dependencies

### DIFF
--- a/src/doc/specifying-dependencies.md
+++ b/src/doc/specifying-dependencies.md
@@ -154,8 +154,9 @@ And that’s it! The next `cargo build` will automatically build `hello_utils` a
 all of its own dependencies, and others can also start using the crate as well.
 However, crates that use dependencies specified with only a path are not
 permitted on [crates.io]. If we wanted to publish our `hello_world` crate, we
-would need to publish a version of `hello_utils` to [crates.io] (or specify a `git`
-repository location) and specify its version in the dependencies line as well:
+would need to publish a version of `hello_utils` to [crates.io](https://crates.io)
+(or specify a `git` repository location) and specify its version in
+the dependencies line as well:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
I just realized when I was replying to #2947, second crates.io link is not working under "Specifying path dependencies".